### PR TITLE
Feat: Update page layouts and colors

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,11 @@
 @tailwind components;
 @tailwind utilities;
 
+.vertical-text {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+}
+
 @layer base {
   :root {
     --background: 0 0% 100%;

--- a/src/pages/Exhibition.tsx
+++ b/src/pages/Exhibition.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 
 const Exhibition = () => {
   return (
-    <div className="min-h-screen font-inter text-black" style={{ backgroundColor: '#ccc' }}>
+    <div className="min-h-screen font-inter text-black bg-custom-bg">
       <div className="container mx-auto px-6 py-20">
         {/* Swiss design grid structure */}
         <div className="max-w-6xl mx-auto">

--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -3,68 +3,68 @@ import { Link } from 'react-router-dom';
 
 const Gallery = () => {
   return (
-    <div className="min-h-screen bg-background text-foreground">
+    <div className="min-h-screen bg-custom-bg text-foreground">
       <div className="mx-auto">
         
         {/* Main gallery container */}
         <article className="overflow-hidden">
           {/* Row 1: 4 items at 25% each on large screens, 50% on small */}
           <div className="float-left w-1/2 lg:w-1/4">
-            <div className="vinyl-item">
+            <div>
               <img src="https://images.unsplash.com/photo-1582562124811-c09040d0a901?w=400&h=400&fit=crop" alt="Artwork 1" />
             </div>
           </div>
           <div className="float-left w-1/2 lg:w-1/4">
-            <div className="vinyl-item">
+            <div>
               <img src="https://images.unsplash.com/photo-1618160702438-9b02ab6515c9?w=400&h=400&fit=crop" alt="Artwork 2" />
             </div>
           </div>
           <div className="float-left w-1/2 lg:w-1/4">
-            <div className="vinyl-item">
+            <div>
               <img src="https://images.unsplash.com/photo-1721322800607-8c38375eef04?w=400&h=400&fit=crop" alt="Artwork 3" />
             </div>
           </div>
           <div className="float-left w-1/2 lg:w-1/4">
-            <div className="vinyl-item">
+            <div>
               <img src="https://images.unsplash.com/photo-1582562124811-c09040d0a901?w=400&h=400&fit=crop" alt="Artwork 4" />
             </div>
           </div>
           
           {/* Row 2: Larger piece takes 50% width, smaller takes 25% on large screens */}
           <div className="float-left w-1/2">
-            <div className="vinyl-item">
+            <div>
               <img src="https://images.unsplash.com/photo-1618160702438-9b02ab6515c9?w=600&h=600&fit=crop" alt="Featured Artwork" />
             </div>
           </div>
           <div className="float-left w-1/2 lg:w-1/4">
-            <div className="vinyl-item">
+            <div>
               <img src="https://images.unsplash.com/photo-1721322800607-8c38375eef04?w=400&h=400&fit=crop" alt="Artwork 5" />
             </div>
           </div>
           
           {/* Row 3: Mixed sizes */}
           <div className="float-left w-full lg:w-1/4">
-            <div className="vinyl-item">
+            <div>
               <img src="https://images.unsplash.com/photo-1582562124811-c09040d0a901?w=400&h=400&fit=crop" alt="Artwork 6" />
             </div>
           </div>
           <div className="float-left w-1/2 lg:w-1/4">
-            <div className="vinyl-item">
+            <div>
               <img src="https://images.unsplash.com/photo-1618160702438-9b02ab6515c9?w=400&h=400&fit=crop" alt="Artwork 7" />
             </div>
           </div>
           <div className="float-left w-1/2 lg:w-1/4">
-            <div className="vinyl-item">
+            <div>
               <img src="https://images.unsplash.com/photo-1721322800607-8c38375eef04?w=400&h=400&fit=crop" alt="Artwork 8" />
             </div>
           </div>
           
           {/* Complex section with stacked items */}
           <div className="float-left w-full md:w-1/2 lg:w-1/4">
-            <div className="vinyl-item">
+            <div>
               <img src="https://images.unsplash.com/photo-1582562124811-c09040d0a901?w=400&h=400&fit=crop" alt="Artwork 9" />
             </div>
-            <div className="vinyl-item">
+            <div>
               <img src="https://images.unsplash.com/photo-1618160702438-9b02ab6515c9?w=400&h=400&fit=crop" alt="Artwork 10" />
             </div>
           </div>
@@ -72,28 +72,28 @@ const Gallery = () => {
           {/* Another complex section */}
           <div className="float-left w-full md:w-1/2 lg:w-1/4">
             <div className="float-left w-full">
-              <div className="vinyl-item">
+              <div>
                 <img src="https://images.unsplash.com/photo-1721322800607-8c38375eef04?w=400&h=400&fit=crop" alt="Artwork 11" />
               </div>
             </div>
             <div className="float-left w-full">
               <div className="float-left w-1/2">
-                <div className="vinyl-item">
+                <div>
                   <img src="https://images.unsplash.com/photo-1582562124811-c09040d0a901?w=200&h=200&fit=crop" alt="Artwork 12" />
                 </div>
               </div>
               <div className="float-left w-1/2">
-                <div className="vinyl-item">
+                <div>
                   <img src="https://images.unsplash.com/photo-1618160702438-9b02ab6515c9?w=200&h=200&fit=crop" alt="Artwork 13" />
                 </div>
               </div>
               <div className="float-left w-1/2">
-                <div className="vinyl-item">
+                <div>
                   <img src="https://images.unsplash.com/photo-1721322800607-8c38375eef04?w=200&h=200&fit=crop" alt="Artwork 14" />
                 </div>
               </div>
               <div className="float-left w-1/2">
-                <div className="vinyl-item">
+                <div>
                   <img src="https://images.unsplash.com/photo-1582562124811-c09040d0a901?w=200&h=200&fit=crop" alt="Artwork 15" />
                 </div>
               </div>
@@ -102,7 +102,7 @@ const Gallery = () => {
           
           {/* Last large item */}
           <div className="float-left w-full lg:w-1/2">
-            <div className="vinyl-item">
+            <div>
               <img src="https://images.unsplash.com/photo-1618160702438-9b02ab6515c9?w=800&h=800&fit=crop" alt="Featured Large Artwork" />
             </div>
           </div>

--- a/src/pages/Painting.tsx
+++ b/src/pages/Painting.tsx
@@ -16,12 +16,12 @@ const paintings = [
 
 const Painting = () => {
   return (
-    <div className="min-h-screen bg-background text-foreground">
+    <div className="min-h-screen bg-custom-bg text-foreground">
       <div className="mx-auto">
         <article className="overflow-hidden">
           <div className="masonry-grid">
             {paintings.map((painting) => (
-              <div key={painting.id} className="masonry-grid-item">
+              <div key={painting.id}>
                 <Dialog>
                   <DialogTrigger asChild>
                     <img src={painting.src} alt={painting.alt} className="w-full h-auto block cursor-pointer" />

--- a/src/pages/Sculpture.tsx
+++ b/src/pages/Sculpture.tsx
@@ -16,24 +16,20 @@ const sculptures = [
 
 const Sculpture = () => {
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <div className="mx-auto">
-        <article className="overflow-hidden">
-          <div className="masonry-grid">
-            {sculptures.map((sculpture) => (
-              <div key={sculpture.id} className="masonry-grid-item">
-                <Dialog>
-                  <DialogTrigger asChild>
-                    <img src={sculpture.src} alt={sculpture.alt} className="w-full h-auto block cursor-pointer" />
-                  </DialogTrigger>
-                  <DialogContent className="p-0 border-0 max-w-none w-auto h-auto">
-                    <img src={sculpture.src.replace('w=400', 'w=1200').replace('h=400', 'h=1200')} alt={sculpture.alt} className="max-h-[90vh] max-w-[90vw] object-contain" />
-                  </DialogContent>
-                </Dialog>
-              </div>
-            ))}
+    <div className="min-h-screen bg-custom-bg text-foreground overflow-hidden">
+      <div className="flex w-full h-screen overflow-x-auto snap-x snap-mandatory">
+        {sculptures.map((sculpture) => (
+          <div key={sculpture.id} className="flex-shrink-0 w-full h-full snap-center flex items-center justify-center">
+            <img
+              src={sculpture.src.replace('w=400', 'w=1200').replace('h=400', 'h=1200')}
+              alt={sculpture.alt}
+              className="h-full w-auto object-contain"
+            />
           </div>
-        </article>
+        ))}
+      </div>
+      <div className="fixed bottom-8 right-8 text-white font-inter text-sm tracking-wider vertical-text">
+        KEEP SCROLLING
       </div>
     </div>
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -56,6 +56,7 @@ export default {
 					DEFAULT: 'hsl(var(--card))',
 					foreground: 'hsl(var(--card-foreground))'
 				},
+        'custom-bg': '#b9bbcc',
 				sidebar: {
 					DEFAULT: 'hsl(var(--sidebar-background))',
 					foreground: 'hsl(var(--sidebar-foreground))',


### PR DESCRIPTION
This commit implements a number of visual changes based on user feedback:

- The background color of the Exhibition, Gallery, Painting, and Sculpture pages has been changed to #b9bbcc.
- The Sculpture page layout has been updated to a full-screen, horizontal scroll-snap view.
- Images on the Sculpture page are now full viewport height and use `object-fit: contain`.
- A "Keep Scrolling" text has been added to the Sculpture page.