### PR TITLE
feat: Update painting page with new images and full-screen view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route, useLocation } from "react-router-dom";
 import BackButton from "./components/BackButton";
 import PageTransition from "./components/PageTransition";
+import { OverlayProvider } from "./context/OverlayContext";
 import { useSmoothScroll } from "./hooks/useSmoothScroll";
 import Index from "./pages/Index";
 import Gallery from "./pages/Gallery";
@@ -43,8 +44,10 @@ const App = () => (
       <Toaster />
       <Sonner />
       <BrowserRouter>
-        <BackButton />
-        <AnimatedRoutes />
+        <OverlayProvider>
+          <BackButton />
+          <AnimatedRoutes />
+        </OverlayProvider>
       </BrowserRouter>
     </TooltipProvider>
   </QueryClientProvider>

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
+import { useOverlay } from '@/context/OverlayContext';
 
 const BackButton = () => {
   const location = useLocation();
+  const { isOverlayVisible } = useOverlay();
 
-  if (location.pathname === '/') {
+  if (location.pathname === '/' || isOverlayVisible) {
     return null;
   }
 

--- a/src/context/OverlayContext.tsx
+++ b/src/context/OverlayContext.tsx
@@ -1,0 +1,26 @@
+import React, { createContext, useState, useContext, ReactNode } from 'react';
+
+interface OverlayContextType {
+  isOverlayVisible: boolean;
+  setIsOverlayVisible: (isVisible: boolean) => void;
+}
+
+const OverlayContext = createContext<OverlayContextType | undefined>(undefined);
+
+export const OverlayProvider = ({ children }: { children: ReactNode }) => {
+  const [isOverlayVisible, setIsOverlayVisible] = useState(false);
+
+  return (
+    <OverlayContext.Provider value={{ isOverlayVisible, setIsOverlayVisible }}>
+      {children}
+    </OverlayContext.Provider>
+  );
+};
+
+export const useOverlay = () => {
+  const context = useContext(OverlayContext);
+  if (context === undefined) {
+    throw new Error('useOverlay must be used within an OverlayProvider');
+  }
+  return context;
+};

--- a/src/pages/Painting.tsx
+++ b/src/pages/Painting.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useImageColor } from '@/hooks/useImageColor';
+import { useOverlay } from '@/context/OverlayContext';
+import { X } from 'lucide-react';
 
 const paintings = [
   { id: 1, src: "https://res.cloudinary.com/thinkdigital/image/upload/v1756651068/giacomo/9go4ianxzSirNb6c4wzcMKU5no_1.jpg", alt: "Painting 1" },
@@ -22,25 +24,27 @@ const Painting = () => {
   const [selectedImage, setSelectedImage] = useState<{ src: string; alt: string } | null>(null);
   const [isOverlayVisible, setIsOverlayVisible] = useState(false);
   const { color: bgColor } = useImageColor(selectedImage?.src || '');
+  const { setIsOverlayVisible: setGlobalOverlayVisible } = useOverlay();
 
   useEffect(() => {
     if (selectedImage) {
-      // Delay to allow the component to mount before transitioning
+      setGlobalOverlayVisible(true);
       const timer = setTimeout(() => setIsOverlayVisible(true), 10);
       return () => clearTimeout(timer);
     }
-  }, [selectedImage]);
+  }, [selectedImage, setGlobalOverlayVisible]);
 
   const openFullScreen = (image: { src: string; alt: string }) => {
     setSelectedImage(image);
+    window.scrollTo(0, 0);
   };
 
   const closeFullScreen = () => {
     setIsOverlayVisible(false);
-    // Delay to allow the transition to finish before unmounting
+    setGlobalOverlayVisible(false);
     setTimeout(() => {
       setSelectedImage(null);
-    }, 500); // This duration should match the transition duration
+    }, 500);
   };
 
   return (
@@ -70,9 +74,9 @@ const Painting = () => {
               e.stopPropagation();
               closeFullScreen();
             }}
-            className="absolute top-4 right-4 text-white text-2xl z-10"
+            className="fixed top-6 right-6 z-50 flex items-center gap-3 text-white backdrop-blur-sm bg-black/20 px-4 py-4 rounded-full hover:bg-black/30 transition-all duration-300"
           >
-            &times;
+            <X className="w-6 h-6" />
           </button>
           <img
             onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
- Replaces the existing images on the painting page with a new set of images.
- Implements a custom full-screen overlay for viewing images, which replaces the previous dialog modal.
- The overlay features a slide-down transition on open and a slide-up transition on close.
- The background color of the overlay is dynamically set to the dominant color of the selected image using the `useImageColor` hook.
- The masonry-style layout is preserved.
- The main back button is hidden when the overlay is active.
- The close button on the overlay is styled to match the back button, with an 'X' icon.
- The page scrolls to the top when the overlay is opened.