### PR TITLE
feat: Update painting page with new images, overlay, and styles

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -133,7 +133,7 @@
 
 .masonry-grid {
   column-count: 3;
-  column-gap: 1em;
+  column-gap: 0;
 }
 
 .masonry-grid-item {

--- a/src/pages/Painting.tsx
+++ b/src/pages/Painting.tsx
@@ -53,8 +53,8 @@ const Painting = () => {
         <article className="overflow-hidden">
           <div className="masonry-grid">
             {paintings.map((painting) => (
-              <div key={painting.id} onClick={() => openFullScreen(painting)}>
-                <img src={painting.src} alt={painting.alt} className="w-full h-auto block cursor-pointer" />
+              <div key={painting.id} onClick={() => openFullScreen(painting)} className="p-1">
+                <img src={painting.src} alt={painting.alt} className="w-full h-auto block cursor-pointer rounded-[22px]" />
               </div>
             ))}
           </div>


### PR DESCRIPTION
This commit introduces a major update to the painting page, including new images, a new full-screen overlay, and several UX and styling improvements.

- Replaces the existing images on the painting page with a new set.
- Implements a custom full-screen overlay for viewing images with a slide-down/up transition.
- The overlay's background color dynamically matches the dominant color of the selected image.
- A new `OverlayContext` is introduced to manage the overlay's visibility globally.
- The main back button is now hidden when the overlay is active.
- The close button on the overlay is restyled to match the back button, using an 'X' icon.
- The page now scrolls to the top when the overlay is opened.
- The gap in the masonry grid has been removed.
- The images in the grid now have a border-radius of 22px.