### PR TITLE
fix: Resolve overlay issues after page transitions

### DIFF
--- a/src/pages/Painting.tsx
+++ b/src/pages/Painting.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { useImageColor } from '@/hooks/useImageColor';
 import { useOverlay } from '@/context/OverlayContext';
 import { X } from 'lucide-react';
@@ -61,7 +62,7 @@ const Painting = () => {
         </article>
       </div>
 
-      {selectedImage && (
+      {selectedImage && createPortal(
         <div
           onClick={closeFullScreen}
           className={`fixed inset-0 z-50 flex items-center justify-center transition-transform duration-500 ease-in-out ${
@@ -84,7 +85,8 @@ const Painting = () => {
             alt={selectedImage.alt}
             className="max-h-full max-w-full object-contain"
           />
-        </div>
+        </div>,
+        document.body
       )}
     </div>
   );


### PR DESCRIPTION
This commit fixes a regression where the full-screen image overlay on the painting page would break after a page transition. The issues included the close button not being fixed, images overflowing the screen, and scroll-to-top behavior failing.

The root cause was identified as the `PageTransition` component, which uses `overflow: hidden` and CSS transforms, interfering with the overlay's `position: fixed` styles.

The fix involves refactoring the overlay to be rendered in a React Portal attached to `document.body`. This removes the overlay from the DOM hierarchy of the `PageTransition` component, isolating it from its styles and ensuring it behaves correctly in all situations.