### PR TITLE
feat: Add image magnifier to overlay

### DIFF
--- a/src/components/ImageMagnifier.tsx
+++ b/src/components/ImageMagnifier.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from 'react';
+import { useIsMobile } from '@/hooks/use-mobile';
+
+interface ImageMagnifierProps {
+  src: string;
+  highResSrc: string;
+  alt: string;
+  className?: string;
+  onClick?: (e: React.MouseEvent<HTMLImageElement>) => void;
+}
+
+const LENS_SIZE = 200;
+const ZOOM_LEVEL = 2.5;
+
+const ImageMagnifier: React.FC<ImageMagnifierProps> = ({
+  src,
+  highResSrc,
+  alt,
+  className,
+  onClick,
+}) => {
+  const isMobile = useIsMobile();
+  const [showMagnifier, setShowMagnifier] = useState(false);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+  const [cursorPosition, setCursorPosition] = useState({ x: 0, y: 0 });
+
+  const handleMouseEnter = () => {
+    setShowMagnifier(true);
+  };
+
+  const handleMouseLeave = () => {
+    setShowMagnifier(false);
+  };
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLImageElement>) => {
+    const { left, top, width, height } = e.currentTarget.getBoundingClientRect();
+    const x = e.pageX - left - window.scrollX;
+    const y = e.pageY - top - window.scrollY;
+
+    setCursorPosition({ x, y });
+
+    const bgX = -((x / width) * 100 * ZOOM_LEVEL - (LENS_SIZE / 2 / width) * 100) + '%';
+    const bgY = -((y / height) * 100 * ZOOM_LEVEL - (LENS_SIZE / 2 / height) * 100) + '%';
+
+    setPosition({ x: bgX, y: bgY });
+  };
+
+  if (isMobile) {
+    return <img src={src} alt={alt} className={className} />;
+  }
+
+  return (
+    <div
+      className="relative"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      <img
+        src={src}
+        alt={alt}
+        className={className}
+        onMouseMove={handleMouseMove}
+        onClick={onClick}
+      />
+
+      {showMagnifier && (
+        <div
+          style={{
+            position: 'absolute',
+            left: `${cursorPosition.x - LENS_SIZE / 2}px`,
+            top: `${cursorPosition.y - LENS_SIZE / 2}px`,
+            width: `${LENS_SIZE}px`,
+            height: `${LENS_SIZE}px`,
+            pointerEvents: 'none',
+            border: '2px solid white',
+            borderRadius: '50%',
+            backgroundImage: `url(${highResSrc})`,
+            backgroundRepeat: 'no-repeat',
+            backgroundSize: `${100 * ZOOM_LEVEL}%`,
+            backgroundPosition: `${position.x} ${position.y}`,
+            zIndex: 100,
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+export default ImageMagnifier;

--- a/src/pages/Painting.tsx
+++ b/src/pages/Painting.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { useImageColor } from '@/hooks/useImageColor';
 import { useOverlay } from '@/context/OverlayContext';
 import { X } from 'lucide-react';
+import ImageMagnifier from '@/components/ImageMagnifier';
 
 const paintings = [
   { id: 1, src: "https://res.cloudinary.com/thinkdigital/image/upload/v1756651068/giacomo/9go4ianxzSirNb6c4wzcMKU5no_1.jpg", alt: "Painting 1" },
@@ -79,11 +80,12 @@ const Painting = () => {
           >
             <X className="w-6 h-6" />
           </button>
-          <img
-            onClick={(e) => e.stopPropagation()}
+          <ImageMagnifier
             src={selectedImage.src}
+            highResSrc={selectedImage.src.replace('/upload/', '/upload/w_2000/')}
             alt={selectedImage.alt}
             className="max-h-full max-w-full object-contain"
+            onClick={(e) => e.stopPropagation()}
           />
         </div>,
         document.body


### PR DESCRIPTION
This commit introduces a new image magnifier feature to the full-screen overlay on the painting page.

- A new `ImageMagnifier` component has been created to encapsulate the zoom-on-hover functionality.
- The magnifier displays a circular lens that shows a high-resolution, zoomed-in view of the image.
- The feature is desktop-only and is disabled on mobile devices, using the `useIsMobile` hook.
- The `ImageMagnifier` is integrated into the `Painting` page's full-screen overlay, using a high-resolution version of the image from Cloudinary for the zoomed view.