### PR TITLE
fix: Correct ImageMagnifier sizing and functionality

### DIFF
--- a/src/components/ImageMagnifier.tsx
+++ b/src/components/ImageMagnifier.tsx
@@ -46,19 +46,19 @@ const ImageMagnifier: React.FC<ImageMagnifierProps> = ({
   };
 
   if (isMobile) {
-    return <img src={src} alt={alt} className={className} />;
+    return <img src={src} alt={alt} className={className} onClick={onClick} />;
   }
 
   return (
     <div
-      className="relative"
+      className={`relative ${className}`}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
       <img
         src={src}
         alt={alt}
-        className={className}
+        className="w-full h-full object-contain"
         onMouseMove={handleMouseMove}
         onClick={onClick}
       />

--- a/src/pages/Painting.tsx
+++ b/src/pages/Painting.tsx
@@ -84,7 +84,7 @@ const Painting = () => {
             src={selectedImage.src}
             highResSrc={selectedImage.src.replace('/upload/', '/upload/w_2000/')}
             alt={selectedImage.alt}
-            className="max-h-full max-w-full object-contain"
+            className="max-h-full max-w-full"
             onClick={(e) => e.stopPropagation()}
           />
         </div>,


### PR DESCRIPTION
This commit fixes two bugs in the `ImageMagnifier` component:
1. The image within the overlay was appearing larger than the viewport.
2. The magnifying lens was empty and not displaying the zoomed content.

The root cause was that the `ImageMagnifier` component's root `div` did not have any sizing constraints, causing the image inside it to render at its intrinsic size instead of being constrained by the overlay container.

The fix applies the sizing `className` (e.g., `max-h-full`, `max-w-full`) to the root `div` of the `ImageMagnifier` component. The inner `img` element is now set to fill this correctly constrained container. This resolves both the image overflow and the empty lens issues.