### PR TITLE
feat(video): Add video page with vertical snap scrolling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import Index from "./pages/Index";
 import Gallery from "./pages/Gallery";
 import Sculpture from "./pages/Sculpture";
 import Painting from "./pages/Painting";
+import Video from "./pages/Video";
 import Exhibition from "./pages/Exhibition";
 import NotFound from "./pages/NotFound";
 
@@ -29,6 +30,7 @@ const AnimatedRoutes = () => {
         <Route path="/gallery" element={<Gallery />} />
         <Route path="/sculpture" element={<Sculpture />} />
         <Route path="/painting" element={<Painting />} />
+        <Route path="/video" element={<Video />} />
         <Route path="/exhibition" element={<Exhibition />} />
         {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
         <Route path="*" element={<NotFound />} />

--- a/src/index.css
+++ b/src/index.css
@@ -154,3 +154,17 @@
     column-count: 1;
   }
 }
+
+.snap-container {
+  scroll-snap-type: y mandatory;
+  overflow-y: scroll;
+  height: 100vh;
+}
+
+.snap-item {
+  scroll-snap-align: start;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/src/pages/Video.tsx
+++ b/src/pages/Video.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+const videos = [
+  { id: 1, src: "https://res.cloudinary.com/thinkdigital/video/upload/v1756679783/giacomo/ZO9XbgRtea1q04wRRzTUEgSkPPs_WdhJF839uIxBYITStVDejwijR2zuHoeRmjq9wFCAVAA.mp4", alt: "Video 1" },
+  { id: 2, src: "https://res.cloudinary.com/thinkdigital/video/upload/v1756679760/giacomo/oka9UtI7DpeIPVRkx8LEMiMjs_Ix-5UB80JQZ8WnO6vurjeuxauPyNDJJIdNcFV0JfUoA.mp4", alt: "Video 2" },
+];
+
+const Video = () => {
+  return (
+    <div className="snap-container">
+      {videos.map((video, index) => (
+        <div key={video.id} className="snap-item" style={{ marginBottom: index === videos.length - 1 ? 0 : 110 }}>
+          <video src={video.src} controls autoPlay loop className="max-h-full max-w-full" />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default Video;


### PR DESCRIPTION
This commit introduces a new video page with a vertical snap scrolling layout.

- Creates a new `Video.tsx` page component.
- Implements a vertical layout with CSS snap scrolling for the videos.
- Adds a new route for the video page in `App.tsx`.
- The videos are displayed in a single column with a 110px gap between them.