### PR TITLE
feat: add high-res image modals, remove gallery, update homepage

### DIFF
--- a/src/pages/Painting.tsx
+++ b/src/pages/Painting.tsx
@@ -5,19 +5,21 @@ import { useOverlay } from '@/context/OverlayContext';
 import { X } from 'lucide-react';
 
 const paintings = [
-  { id: 1, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652783/IMG_5607_iansk0.jpg", alt: "Painting 1" },
-  { id: 2, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652782/IMG_6800_nlovla.jpg", alt: "Painting 2" },
-  { id: 3, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652781/IMG_7839_wyzh9z.jpg", alt: "Painting 3" },
-  { id: 4, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652782/IMG_6806_yrnoju.jpg", alt: "Painting 4" },
-  { id: 5, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652781/IMG_8010_csrf0s.jpg", alt: "Painting 5" },
-  { id: 6, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652780/IMG_8554_kfqpap.jpg", alt: "Painting 6" },
-  { id: 7, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652780/IMG_8792_gcgrwz.jpg", alt: "Painting 7" },
-  { id: 8, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652780/IMG_8778_a8nvwt.jpg", alt: "Painting 8" },
-  { id: 9, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652780/IMG_8946_toxuml.jpg", alt: "Painting 9" },
+  { id: 1, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652783/IMG_5607_iansk0.jpg", fullSrc: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782655942/IMG_5607_oygghd.jpg", alt: "Painting 1" },
+  { id: 2, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652782/IMG_6800_nlovla.jpg", fullSrc: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782655925/IMG_6800_owjxqe.jpg", alt: "Painting 2" },
+  { id: 3, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652781/IMG_7839_wyzh9z.jpg", fullSrc: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782655930/IMG_7839_eqeh3t.jpg", alt: "Painting 3" },
+  { id: 4, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652782/IMG_6806_yrnoju.jpg", fullSrc: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782655942/IMG_6806_aco3fp.jpg", alt: "Painting 4" },
+  { id: 5, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652781/IMG_8010_csrf0s.jpg", fullSrc: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782655940/IMG_8010_rcng6d.jpg", alt: "Painting 5" },
+  { id: 6, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652780/IMG_8554_kfqpap.jpg", fullSrc: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782655939/IMG_8554_hftpjb.jpg", alt: "Painting 6" },
+  { id: 7, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652780/IMG_8792_gcgrwz.jpg", fullSrc: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782655933/IMG_8792_hso3du.jpg", alt: "Painting 7" },
+  { id: 8, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652780/IMG_8778_a8nvwt.jpg", fullSrc: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782655932/IMG_8778_ldbx3u.jpg", alt: "Painting 8" },
+  { id: 9, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652780/IMG_8946_toxuml.jpg", fullSrc: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782655941/IMG_8946_xj7giq.jpg", alt: "Painting 9" },
+  { id: 10, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782655940/IMG_2980_h4xlid.jpg", fullSrc: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782655940/IMG_2980_h4xlid.jpg", alt: "Painting 10" },
+  { id: 11, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782655933/IMG_5410_gosj5z.jpg", fullSrc: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782655933/IMG_5410_gosj5z.jpg", alt: "Painting 11" },
 ];
 
 const Painting = () => {
-  const [selectedImage, setSelectedImage] = useState<{ src: string; alt: string } | null>(null);
+  const [selectedImage, setSelectedImage] = useState<{ src: string; fullSrc: string; alt: string } | null>(null);
   const [isOverlayVisible, setIsOverlayVisible] = useState(false);
   const { color: bgColor } = useImageColor(selectedImage?.src || '');
   const { setIsOverlayVisible: setGlobalOverlayVisible } = useOverlay();
@@ -30,7 +32,7 @@ const Painting = () => {
     }
   }, [selectedImage, setGlobalOverlayVisible]);
 
-  const openFullScreen = (image: { src: string; alt: string }) => {
+  const openFullScreen = (image: { src: string; fullSrc: string; alt: string }) => {
     setSelectedImage(image);
     window.scrollTo(0, 0);
   };
@@ -84,7 +86,7 @@ const Painting = () => {
           </button>
           <img
             onClick={(e) => e.stopPropagation()}
-            src={selectedImage.src}
+            src={selectedImage.fullSrc}
             alt={selectedImage.alt}
             className="max-h-full max-w-full object-contain"
           />

--- a/src/pages/Sculpture.tsx
+++ b/src/pages/Sculpture.tsx
@@ -5,18 +5,18 @@ import { useOverlay } from '@/context/OverlayContext';
 import { X } from 'lucide-react';
 
 const sculptures = [
-  { id: 1, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652757/DSC_4027_cf3fkz.jpg", alt: "Sculpture 1" },
-  { id: 2, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652757/bd2401a8-1b63-4d32-96f1-d47690361977_zhuq2q.jpg", alt: "Sculpture 2" },
-  { id: 3, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652756/DSC_8500_qzhhv1.jpg", alt: "Sculpture 3" },
-  { id: 4, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652756/DSC_8594_scieud.jpg", alt: "Sculpture 4" },
-  { id: 5, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652756/spaghetti_dwfrku.jpg", alt: "Sculpture 5" },
-  { id: 6, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652756/IMG_1123_s50ysv.jpg", alt: "Sculpture 6" },
-  { id: 7, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652756/underwood_wj1ld8.jpg", alt: "Sculpture 7" },
-  { id: 8, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652756/DSC_0001_pgdyoi.jpg", alt: "Sculpture 8" },
+  { id: 1, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652757/DSC_4027_cf3fkz.jpg", fullSrc: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782655947/DSC_4027_wivxai.jpg", alt: "Sculpture 1" },
+  { id: 2, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652757/bd2401a8-1b63-4d32-96f1-d47690361977_zhuq2q.jpg", fullSrc: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782655944/bd2401a8-1b63-4d32-96f1-d47690361977_wmbnfh.jpg", alt: "Sculpture 2" },
+  { id: 3, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652756/DSC_8500_qzhhv1.jpg", fullSrc: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782655949/DSC_8500_vktyzr.jpg", alt: "Sculpture 3" },
+  { id: 4, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652756/DSC_8594_scieud.jpg", fullSrc: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782655946/DSC_8594_qxdplp.jpg", alt: "Sculpture 4" },
+  { id: 5, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652756/spaghetti_dwfrku.jpg", fullSrc: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782655949/spaghetti_hlxkx4.jpg", alt: "Sculpture 5" },
+  { id: 6, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652756/IMG_1123_s50ysv.jpg", fullSrc: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782655950/IMG_1123_pu59mf.jpg", alt: "Sculpture 6" },
+  { id: 7, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652756/underwood_wj1ld8.jpg", fullSrc: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782655949/underwood_pzc97c.jpg", alt: "Sculpture 7" },
+  { id: 8, src: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652756/DSC_0001_pgdyoi.jpg", fullSrc: "https://res.cloudinary.com/dg9st86xi/image/upload/v1782652756/DSC_0001_pgdyoi.jpg", alt: "Sculpture 8" }, // No full size provided for DSC_0001
 ];
 
 const Sculpture = () => {
-  const [selectedImage, setSelectedImage] = useState<{ src: string; alt: string } | null>(null);
+  const [selectedImage, setSelectedImage] = useState<{ src: string; fullSrc: string; alt: string } | null>(null);
   const [isOverlayVisible, setIsOverlayVisible] = useState(false);
   const { color: bgColor } = useImageColor(selectedImage?.src || '');
   const { setIsOverlayVisible: setGlobalOverlayVisible } = useOverlay();
@@ -29,7 +29,7 @@ const Sculpture = () => {
     }
   }, [selectedImage, setGlobalOverlayVisible]);
 
-  const openFullScreen = (image: { src: string; alt: string }) => {
+  const openFullScreen = (image: { src: string; fullSrc: string; alt: string }) => {
     setSelectedImage(image);
     window.scrollTo(0, 0);
   };
@@ -83,7 +83,7 @@ const Sculpture = () => {
           </button>
           <img
             onClick={(e) => e.stopPropagation()}
-            src={selectedImage.src}
+            src={selectedImage.fullSrc}
             alt={selectedImage.alt}
             className="max-h-full max-w-full object-contain"
           />

--- a/vite_out.txt
+++ b/vite_out.txt
@@ -1,9 +1,0 @@
-
-> vite_react_shadcn_ts@0.0.0 dev
-> vite
-
-Port 8080 is in use, trying another one...
-
-  VITE v5.4.10  ready in 1074 ms
-
-  ➜  Local:   http://127.0.0.1:8081/


### PR DESCRIPTION
- Updated images on Sculpture and Painting pages to display high-resolution versions in a full-screen modal when clicked.
- Deleted the Gallery page and removed all associated routes and navigation links from `App.tsx`, `Header.tsx`, and `ArtworkInfo.tsx`.
- Updated the copyright year in the footer to 2026.
- Updated the background image on the homepage (`Hero.tsx`).
- Resolved minor linting errors by converting interface to type in shadcn UI components and using ES Module syntax in `tailwind.config.ts`.